### PR TITLE
docs(readme): clarify contribution guidelines and licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,27 @@
-<img width="872" alt="image" src="https://user-images.githubusercontent.com/1511906/223094313-879ff9ca-9825-4335-87f6-b32d94939945.png">
+# StackBlitz Starter Templates
 
-### About the project
+## About this repository
 
-StackBlitz utilizes git repositories as the source of the Starters on the [stackblitz.com](https://stackblitz.com) platform.
-Some of these starters are provided by various frameworks' respective communities (see e.g. the [Nuxt repository](https:github.com/nuxt/starter/tree/v3-stackblitz))
+StackBlitz uses Git repositories as the source of the __starter templates__ on [stackblitz.com](https://stackblitz.com). This repository contains the source code for several starter templates maintained by the StackBlitz team and community.
 
-This repository provides the source for the remaining starters.
+Some open-source projects maintain starter templates in their own repositories. For examples, see the [create-vite templates](https://github.com/vitejs/vite/tree/main/packages/create-vite) and the [`nuxt/starter` repository](https:github.com/nuxt/starter/tree/v3-stackblitz).
 
-#### Note
+## Contributing to this repository
 
-This repository doesn't specify the existence or specific listing of the starters on the StackBlitz pages.
+Contributions to this repository are welcome. We ask that contributors first open an issue before opening a pull request for non-trivial changes, such as:
+
+1. Adding a new template.
+2. Upgrading a template’s npm dependencies to new major versions.
+3. Changing many files in an existing template (except for formatting or cosmetic changes).
+
+__Please note:__ the presence of a starter template in this repository does not guarantee that this template will be included on stackblitz.com. The list of starter templates on stackblitz.com (pictured below) is currently hand-picked by the StackBlitz team.
+
+<img width="872" alt="Screenshot of the list of starter templates on stackblitz.com" src="https://user-images.githubusercontent.com/1511906/223094313-879ff9ca-9825-4335-87f6-b32d94939945.png">
+
+## License
+
+The contents of this repository are made available under the terms of the [MIT License](./LICENSE).
+
+By contributing code changes to this repository, you agree to StackBlitz distributing those code changes under this license.
+
+Note that each starter template in this repository may specify — but not directly include — dependencies which are licensed separately by their respective authors. Please check licensing requirements for the dependencies and software packages you use.


### PR DESCRIPTION
Partial rewrite of the `README.md` with:

- Add main heading and fix heading hierarchy.
- Language tweaks (use `for example` instead of `e.g.`, `use` instead of `utilize`, etc.)
- Naming convention: I used the phrase “starter templates” consistently instead of just “starters” because that’s what we’re using in the StackBlitz dashboard. Looking at https://developer.stackblitz.com we are using “starter projects” (most common), “project starters”, and there is one instance of “base template” and one of “starter templates”. Personally I’m not 100% convinced “starter templates” work for us, because we already use the word “template” with a different meaning in our SDK (for the `project.template` option).
- Add Contributing section.
- Add Licensing section.

All those choses are “best guess” efforts, and I’m open to any and all changes.