### PR TITLE
vue template: update to latest @vue/cli

### DIFF
--- a/vue/package.json
+++ b/vue/package.json
@@ -3,19 +3,14 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "build": "vue-cli-service build"
   },
   "dependencies": {
     "vue": "^3.3.4"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "^4.4.0",
-    "@vue/cli-plugin-eslint": "^4.4.0",
-    "@vue/cli-service": "^4.4.0",
-    "babel-eslint": "^10.1.0",
-    "eslint": "^6.7.2",
-    "eslint-plugin-vue": "^6.2.2",
-    "vue-template-compiler": "^2.6.11"
+    "core-js": "^3.32.2",
+    "@vue/cli-plugin-babel": "^5.0.8",
+    "@vue/cli-service": "^5.0.8"
   }
 }

--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -1,19 +1,24 @@
 <template>
   <div id="app">
-    <img alt="Vue logo" src="https://vuejs.org/images/logo.png">
-    <HelloWorld msg="Welcome to Your Vue.js App"/>
+    <img
+      alt="Vue logo"
+      width="200"
+      height="200"
+      src="https://vuejs.org/images/logo.png"
+    />
+    <HelloWorld msg="Welcome to Your Vue.js App" />
   </div>
 </template>
 
 <script>
-import HelloWorld from './components/HelloWorld.vue'
+import HelloWorld from './components/HelloWorld.vue';
 
 export default {
   name: 'App',
   components: {
-    HelloWorld
-  }
-}
+    HelloWorld,
+  },
+};
 </script>
 
 <style>

--- a/vue/src/components/HelloWorld.vue
+++ b/vue/src/components/HelloWorld.vue
@@ -2,14 +2,12 @@
   <div class="hello">
     <h1>{{ msg }}</h1>
     <p>
-      For a guide and recipes on how to configure / customize this project,<br>
-      check out the
+      For a guide and recipes on how to configure / customize this project, check out the
       <a href="https://cli.vuejs.org" target="_blank" rel="noopener">vue-cli documentation</a>.
     </p>
     <h3>Installed CLI Plugins</h3>
     <ul>
       <li><a href="https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-babel" target="_blank" rel="noopener">babel</a></li>
-      <li><a href="https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-eslint" target="_blank" rel="noopener">eslint</a></li>
     </ul>
     <h3>Essential Links</h3>
     <ul>

--- a/vue/src/main.js
+++ b/vue/src/main.js
@@ -1,4 +1,4 @@
-const { createApp } = require('vue');
+import { createApp } from 'vue';
 import App from './App.vue';
 
 createApp(App).mount('#app');


### PR DESCRIPTION
This updates the `vue` template (EngineBlock) to use the latest `@vue/cli` (v5, instead of v4).

### Goals and technical choices

My goal was to make sure that a downloaded project could install and run with Node and npm with no friction. In my tests, the current template worked, but logged incompatible runtime warnings with Node 18 (some dependency was marked as compatible with Node up to 16; Node 16 is end-of-life as of this week).

Note that Vue CLI, which wraps webpack, is in maintenance mode. The Vue project currently recommends using Vite instead. But the coding conventions for the project's `index.html` used by Vite are not compatible with EngineBlock at this time (see #18 for a similar issue with our React templates), so for now we should keep using `@vue/cli` in the template's `devDependencies`.

## Methodology for this update

I created a new `@vue/cli` project with:

```sh
npx @vue/cli create hello-world
```

In the project creation wizard, I chose a custom config, and disabled ESLint (by default the two enabled plugins are `babel` and `eslint`).

My rationale for this was: we don't run linting on EngineBlock or in the StackBlitz classic editor, and we'd like to keep the dependencies down to a minimum. Do push back if you think we do need `eslint`.

<img width="658" alt="Vue CLI project creation wizard, showing several options such as Babel, TypeScript, ESLint and more, with only Babel selected" src="https://github.com/stackblitz/starters/assets/243601/adbfcc6e-ae2e-468f-957c-aadb748463e9">

Then I copied from the generated files into the `vue` template, trying to respect the modifications we had done before.
