### PR TITLE
chore: update TS target to ES2022

### DIFF
--- a/angular/tsconfig.json
+++ b/angular/tsconfig.json
@@ -16,7 +16,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "ES2015",
+    "target": "ES2022",
     "module": "ES2022",
     "useDefineForClassFields": false,
     "lib": ["ES2022", "dom"]


### PR DESCRIPTION
With webcontainers now enabled by default, the CLI is building the angular app. The CLI downlevels native async/awaits (via babel) to support zone.js patching and there is no need to target <ES2017 anymore (where TSC was doing the down leveling).

Moving to ES2022 removes the following warning in the console: `TypeScript compiler options "target" and "useDefineForClassFields" are set to "ES2022" and "false" respectively by the Angular CLI.` when starting a project