### PR TITLE
chore(angular): add base href tag

### DIFF
--- a/angular/src/index.html
+++ b/angular/src/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>My app</title>
     <meta charset="UTF-8" />
+    <base href="/">
   </head>
   <body>
     <app-root>Loading...</app-root>


### PR DESCRIPTION
This PR adds the `base href` tag to the Angular template. It makes sure that when routing is added later, refreshing the page works correctly.

See https://github.com/stackblitz/webcontainer-core/issues/1483