### PR TITLE
Replace Custom Angular Builder with Standard Angular CLI Builder

### DIFF
--- a/angular/angular.json
+++ b/angular/angular.json
@@ -8,7 +8,7 @@
     "demo": {
       "architect": {
         "build": {
-          "builder": "@angular/build:application",
+          "builder": "@angular-devkit/build-angular:application",
           "configurations": {
             "development": {
               "extractLicenses": false,
@@ -37,7 +37,7 @@
           }
         },
         "serve": {
-          "builder": "@angular/build:dev-server",
+          "builder": "@@angular-devkit/build-angular:dev-server",
           "configurations": {
             "development": {
               "buildTarget": "demo:build:development"

--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -6,21 +6,21 @@
     "": {
       "name": "angular-starter",
       "dependencies": {
-        "@angular/animations": "^19.0.0",
-        "@angular/common": "^19.0.0",
-        "@angular/compiler": "^19.0.0",
-        "@angular/core": "^19.0.0",
-        "@angular/forms": "^19.0.0",
-        "@angular/platform-browser": "^19.0.0",
-        "@angular/router": "^19.0.0",
+        "@angular/animations": "^19.0.5",
+        "@angular/common": "^19.0.5",
+        "@angular/compiler": "^19.0.5",
+        "@angular/core": "^19.0.5",
+        "@angular/forms": "^19.0.5",
+        "@angular/platform-browser": "^19.0.5",
+        "@angular/router": "^19.0.5",
         "rxjs": "^7.8.1",
         "tslib": "^2.5.0",
         "zone.js": "~0.15.0"
       },
       "devDependencies": {
-        "@angular/build": "^19.0.0",
-        "@angular/cli": "^19.0.0",
-        "@angular/compiler-cli": "^19.0.0",
+        "@angular/build": "^19.0.6",
+        "@angular/cli": "^19.0.6",
+        "@angular/compiler-cli": "^19.0.5",
         "typescript": "^5.6.3"
       }
     },
@@ -38,12 +38,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1900.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1900.0.tgz",
-      "integrity": "sha512-oC2CyKf9olKvthEwp2wmkKw+H9NhpnK9cWYHvajWeCRJ8A4DLaKwfMuZ9lioi92QPourrJzoikgp7C6m2AuuZQ==",
+      "version": "0.1900.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1900.6.tgz",
+      "integrity": "sha512-w11bAXQnNWBawTJfQPjvaTRrzrqsOUm9tK9WNvaia/xjiRFpmO0CfmKtn3axNSEJM8jb/czaNQrgTwG+TGc/8g==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "19.0.0",
+        "@angular-devkit/core": "19.0.6",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.0.tgz",
-      "integrity": "sha512-/EJQOKVFb9vsFbPR+57C7fJHFVr7le9Ru6aormIKw24xyZZHtt5X4rwdeN7l6Zkv8F0cJ2EoTSiQoY17090DLQ==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.6.tgz",
+      "integrity": "sha512-WUWJhzQDsovfMY6jtb9Ktz/5sJszsaErj+XV2aXab85f1OweI/Iv2urPZnJwUSilvVN5Ok/fy3IJ6SuihK4Ceg==",
       "dev": true,
       "dependencies": {
         "ajv": "8.17.1",
@@ -80,12 +80,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.0.0.tgz",
-      "integrity": "sha512-90pGZtpZgjDk1UgRBatfeqYP6qUZL9fLh+8zIpavOr2ey5bW2lADO7mS2Qrc7U1SmGqnxQXQQ7uIS+50gYm0tQ==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.0.6.tgz",
+      "integrity": "sha512-R9hlHfAh1HKoIWgnYJlOEKhUezhTNl0fpUmHxG2252JSY5FLRxmYArTtJYYmbNdBbsBLNg3UHyM/GBPvJSA3NQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "19.0.0",
+        "@angular-devkit/core": "19.0.6",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.12",
         "ora": "5.4.1",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.0.0.tgz",
-      "integrity": "sha512-+uZTvEXjYh8PZKB4ijk8uuH1K+Tz/A67mUlltFv9pYKtnmbZAeS/PI66g/7pigRYDvEgid1fvlAANeBShAiPZQ==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.0.5.tgz",
+      "integrity": "sha512-HCOF2CrhUvjoZWusd4nh32VOxpUrg6bV+3Z8Q36Ix3aZdni8v0qoP2rl5wGbotaPtYg5RtyDH60Z2AOPKqlrZg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -108,17 +108,17 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.0.0"
+        "@angular/core": "19.0.5"
       }
     },
     "node_modules/@angular/build": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.0.0.tgz",
-      "integrity": "sha512-OLyUwAVCSqW589l19g19aP2O1NpBMRPsqKmYLaTYvYSIcZkNRJPxOcsCIDGB3FUQUEjpouYtzPA3RtBuJWsCwQ==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.0.6.tgz",
+      "integrity": "sha512-KEVNLgTZUF2dfpOYQn+yR2HONHUTxq/2rFVhiK9qAvrm/m+uKJNEXx7hGtbRyoqenZff4ScJq+7feITUldfX8g==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1900.0",
+        "@angular-devkit/architect": "0.1900.6",
         "@babel/core": "7.26.0",
         "@babel/helper-annotate-as-pure": "7.25.9",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -157,7 +157,7 @@
         "@angular/localize": "^19.0.0",
         "@angular/platform-server": "^19.0.0",
         "@angular/service-worker": "^19.0.0",
-        "@angular/ssr": "^19.0.0",
+        "@angular/ssr": "^19.0.6",
         "less": "^4.2.0",
         "postcss": "^8.4.0",
         "tailwindcss": "^2.0.0 || ^3.0.0",
@@ -188,17 +188,17 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.0.0.tgz",
-      "integrity": "sha512-7FTNkMtTuaXp4CCWZlRIwFZtnkDJg+YjqAuloDNGhIXDjDsb9gWihepWpWXSMBTg4XI1OdsT+oYt38Z0YMck0A==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.0.6.tgz",
+      "integrity": "sha512-ZEHhgRRVIdn10dbsAjB8TE9Co32hfuL9/im5Jcfa1yrn6KJefmigz6KN8Xu7FXMH5FkdqfQ11QpLBxJSPb9aww==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1900.0",
-        "@angular-devkit/core": "19.0.0",
-        "@angular-devkit/schematics": "19.0.0",
+        "@angular-devkit/architect": "0.1900.6",
+        "@angular-devkit/core": "19.0.6",
+        "@angular-devkit/schematics": "19.0.6",
         "@inquirer/prompts": "7.1.0",
         "@listr2/prompt-adapter-inquirer": "2.0.18",
-        "@schematics/angular": "19.0.0",
+        "@schematics/angular": "19.0.6",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "5.0.0",
         "jsonc-parser": "3.3.1",
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.0.0.tgz",
-      "integrity": "sha512-kb2iS26GZS0vyR3emAQbIiQifnK5M5vnbclEHni+pApDEU5V9FufbdRP3vCxs28UHZvAZKB0LrxkTrnT6T+z5g==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.0.5.tgz",
+      "integrity": "sha512-fFK+euCj1AjBHBCpj9VnduMSeqoMRhZZHbhPYiND7tucRRJ8vwGU0sYK2KI/Ko+fsrNIXL/0O4F36jVPl09Smg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -231,14 +231,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.0.0",
+        "@angular/core": "19.0.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.0.0.tgz",
-      "integrity": "sha512-Uw2Yy25pdqfzKsS9WofnIq1zvknlVYyy03LYO7NMKHlFWiy8q8SIXN7WKPFhiHlOfyACXipp4eZb9m3+IbOfSA==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.0.5.tgz",
+      "integrity": "sha512-S8ku5Ljp0kqX3shfmE9DVo09629jeYJSlBRGbj2Glb92dd+VQZPOz7KxqKRTwmAl7lQIV/+4Lr6G/GVTsoC4vg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -246,7 +246,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.0.0"
+        "@angular/core": "19.0.5"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -255,9 +255,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.0.0.tgz",
-      "integrity": "sha512-2PxpsIeppoDLAx7A6i0GE10WjC+Fkz8tTQioa7r4y/+eYnniEjJFIQM/8lbkOnRVcuYoeXoNyYWr3fEQAyO4LA==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.0.5.tgz",
+      "integrity": "sha512-KSzuWCTZlvJsoAenxM9cjTOzNM8mrFxDBInj0KVPz7QU83amGS4rcv1pWO/QGYQcErfskcN84TAdMegaRWWCmA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.26.0",
@@ -278,14 +278,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "19.0.0",
+        "@angular/compiler": "19.0.5",
         "typescript": ">=5.5 <5.7"
       }
     },
     "node_modules/@angular/core": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.0.0.tgz",
-      "integrity": "sha512-aNG2kd30BOM/zf0jC+aEVG8OA27IwqCki9EkmyRNYnaP2O5Mj1n7JpCyZGI+0LrWTJ2UUCfRNZiZdZwmNThr1Q==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.0.5.tgz",
+      "integrity": "sha512-Ywc6sPO6G/Y1stfk3y/MallV/h0yzQ0vdOHRWueLrk5kD1DTdbolV4X03Cs3PuVvravgcSVE3nnuuHFuH32emQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.0.0.tgz",
-      "integrity": "sha512-gM4bUdlIJ0uRYNwoVMbXiZt4+bZzPXzyQ7ByNIOVKEAI0PN9Jz1dR1pSeQgIoUvKQbhwsVKVUoa7Tn1hoqwvTg==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.0.5.tgz",
+      "integrity": "sha512-OhNFkfOoguqCDq07vNBV28FFrmTM8S11Z3Cd6PQZJJF9TgAtpV5KtF7A3eXBCN92W4pmqluomPjfK7YyImzIYQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -308,16 +308,16 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.0.0",
-        "@angular/core": "19.0.0",
-        "@angular/platform-browser": "19.0.0",
+        "@angular/common": "19.0.5",
+        "@angular/core": "19.0.5",
+        "@angular/platform-browser": "19.0.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.0.0.tgz",
-      "integrity": "sha512-g9Qkv+KgEmXLVeg+dw1edmWsRBspUGeJMOBf2UX1kUCw6txeco+pzCMimouB5LQYHfs6cD6oC+FwINm0HNwrhg==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.0.5.tgz",
+      "integrity": "sha512-41+Jo5DEil4Ifvv+UE/p1l9YJtYN+xfhx+/C9cahVgvV5D2q+givyK73d0Mnb6XOfe1q+hoV5lZ+XhQYp21//g==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -325,9 +325,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "19.0.0",
-        "@angular/common": "19.0.0",
-        "@angular/core": "19.0.0"
+        "@angular/animations": "19.0.5",
+        "@angular/common": "19.0.5",
+        "@angular/core": "19.0.5"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -336,9 +336,9 @@
       }
     },
     "node_modules/@angular/router": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-19.0.0.tgz",
-      "integrity": "sha512-uFyT8DWVLGY8k0AZjpK7iyMO/WwT4/+b09Ax0uUEbdcRxTXSOg8/U/AVzQWtxzxI80/vJE2WZMmhIJFUTYwhKA==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-19.0.5.tgz",
+      "integrity": "sha512-6tNubVVj/rRyTg+OXjQxACfufvCLHAwDQtv9wqt6q/3OYSnysHTik3ho3FaFPwu7fXJ+6p9Rjzkh2VY9QMk4bw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -346,9 +346,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.0.0",
-        "@angular/core": "19.0.0",
-        "@angular/platform-browser": "19.0.0",
+        "@angular/common": "19.0.5",
+        "@angular/core": "19.0.5",
+        "@angular/platform-browser": "19.0.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -2642,13 +2642,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.0.0.tgz",
-      "integrity": "sha512-2U8dlhURoQfS99ZF67RVeARFeJn4Z0Lg2dfYbGj+ooRH5YMtAZq8zAIRCfyC3OMiJEZM6BbGigCD6gNoAhP0RQ==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.0.6.tgz",
+      "integrity": "sha512-HicclmbW/+mlljU7a4PzbyIWG+7tognoL5LsgMFJQUDzJXHNjRt1riL0vk57o8Pcprnz9FheeWZXO1KRhXkQuw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "19.0.0",
-        "@angular-devkit/schematics": "19.0.0",
+        "@angular-devkit/core": "19.0.6",
+        "@angular-devkit/schematics": "19.0.6",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -3243,6 +3243,37 @@
         }
       ]
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -3812,9 +3843,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
-      "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
       "dev": true
     },
     "node_modules/fastq": {
@@ -3971,6 +4002,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -4516,58 +4556,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/log-symbols/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/log-symbols/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/log-symbols/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/log-update": {
@@ -5549,37 +5537,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ora/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ora/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/ora/node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -5588,15 +5545,6 @@
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ora/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5634,18 +5582,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "node_modules/ora/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/ordered-binary": {
       "version": "1.5.3",
@@ -6482,6 +6418,18 @@
       "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"

--- a/angular/package.json
+++ b/angular/package.json
@@ -7,21 +7,21 @@
     "build": "ng build"
   },
   "dependencies": {
-    "@angular/animations": "^19.0.0",
-    "@angular/common": "^19.0.0",
-    "@angular/compiler": "^19.0.0",
-    "@angular/core": "^19.0.0",
-    "@angular/forms": "^19.0.0",
-    "@angular/platform-browser": "^19.0.0",
-    "@angular/router": "^19.0.0",
+    "@angular/animations": "^19.0.5",
+    "@angular/common": "^19.0.5",
+    "@angular/compiler": "^19.0.5",
+    "@angular/core": "^19.0.5",
+    "@angular/forms": "^19.0.5",
+    "@angular/platform-browser": "^19.0.5",
+    "@angular/router": "^19.0.5",
     "rxjs": "^7.8.1",
     "tslib": "^2.5.0",
     "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular/build": "^19.0.0",
-    "@angular/cli": "^19.0.0",
-    "@angular/compiler-cli": "^19.0.0",
+    "@angular/build": "^19.0.6",
+    "@angular/cli": "^19.0.6",
+    "@angular/compiler-cli": "^19.0.5",
     "typescript": "^5.6.3"
   }
 }


### PR DESCRIPTION
This PR resolves the issue where the Angular build process fails with the error Angular compilation initialization failed when using template literals for styles (styles: \...``).

Fix for #49 