### PR TITLE
feat: send ready event for expo starter

### DIFF
--- a/bolt-expo/app/_layout.tsx
+++ b/bolt-expo/app/_layout.tsx
@@ -1,7 +1,18 @@
+import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 
+declare global {
+  interface Window {
+    frameworkReady?: () => void;
+  }
+}
+
 export default function RootLayout() {
+  useEffect(() => {
+    window.frameworkReady?.();
+  }, []);
+
   return (
     <>
       <Stack screenOptions={{ headerShown: false }}>


### PR DESCRIPTION
This PR adds the call to `frameworkReady` to notify the environment that the preview is ready.