### PR TITLE
feat(expo): remove env vars

### DIFF
--- a/bolt-expo/.env
+++ b/bolt-expo/.env
@@ -1,7 +1,0 @@
-EXPO_NO_TELEMETRY=1
-EXPO_NO_DEPENDENCY_VALIDATION=1
-EXPO_OFFLINE=1
-EXPO_USE_FAST_RESOLVER=1
-EXPO_PACKAGER_PROXY_URL=http://lunchboxj6nvjpwm-ax4q.boltexpo.dev
-REACT_NATIVE_PACKAGER_HOSTNAME=lunchboxj6nvjpwm-ax4q.boltexpo.dev
-EXPO_CLOUDFLARE_PROXY_URL=wss://lunchboxj6nvjpwm-ax4q.boltexpo.dev

--- a/bolt-expo/package.json
+++ b/bolt-expo/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "expo start",
+    "dev": "EXPO_NO_TELEMETRY=1 expo start",
     "build:web": "expo export --platform web",
     "lint": "expo lint"
   },


### PR DESCRIPTION
This updates the Expo starter and removes the `.env` file and inlines `EXPO_NO_TELEMETRY` in the `package.json`.