### PR TITLE
fix(expo): set output to single to avoid rendering errors

### DIFF
--- a/bolt-expo/app.json
+++ b/bolt-expo/app.json
@@ -13,7 +13,7 @@
     },
     "web": {
       "bundler": "metro",
-      "output": "static",
+      "output": "single",
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": ["expo-router"],


### PR DESCRIPTION
This seems to fix issues that people are running into where the CLI crashes saying `window is undefined`.