### PR TITLE
fix: update expo starter

### DIFF
--- a/bolt-expo/package-lock.json
+++ b/bolt-expo/package-lock.json
@@ -2651,9 +2651,9 @@
       }
     },
     "node_modules/@expo/ws-tunnel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-1.0.4.tgz",
-      "integrity": "sha512-spXCVXxbeKOe8YZ9igd+MDfXZe6LeDvFAdILijeTSG+XcxGrZLmqMWWkFKR0nV8lTWZ+NugUT3CoiXmEuKKQ7w=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-1.0.6.tgz",
+      "integrity": "sha512-nDRbLmSrJar7abvUjp3smDwH8HcbZcoOEa5jVPUv9/9CajgmWw20JNRwTuBRzWIWIkEJDkz20GoNA+tSwUqk0Q=="
     },
     "node_modules/@expo/xcpretty": {
       "version": "4.3.2",


### PR DESCRIPTION
This PR updates the expo starter with the latest version of `@expo/ws-tunnel`.