### PR TITLE
fix: update expo-camera

### DIFF
--- a/bolt-expo/package-lock.json
+++ b/bolt-expo/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^7.0.14",
         "expo": "52.0.33",
         "expo-blur": "^14.0.3",
+        "expo-camera": "^16.0.18",
         "expo-constants": "^17.0.5",
         "expo-font": "^13.0.3",
         "expo-haptics": "^14.0.1",
@@ -5807,6 +5808,26 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "16.0.18",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-16.0.18.tgz",
+      "integrity": "sha512-NP5u2yyc+wZc9GdUXH+jcEytyXZwBnHxItMwXoZQQxi4wgltwvs4XfSWjBtRZe1LngnhpBfPyPJV0aShjWlLDg==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-constants": {

--- a/bolt-expo/package.json
+++ b/bolt-expo/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/native": "^7.0.14",
     "expo": "52.0.33",
     "expo-blur": "^14.0.3",
+    "expo-camera": "^16.0.18",
     "expo-constants": "^17.0.5",
     "expo-font": "^13.0.3",
     "expo-haptics": "^14.0.1",


### PR DESCRIPTION
the llm uses an old version of expo-camera which often leads to many issues.