### PR TITLE
fix: add proper redirect to tabs

### DIFF
--- a/.github/workflows/per-starter-release.yml
+++ b/.github/workflows/per-starter-release.yml
@@ -1,34 +1,39 @@
-name: Per-Starter Release
+# .github/workflows/release-template.yml
+
+name: Release Individual Starter
 
 on:
   push:
     tags:
-      - "*-v*"
+      - '*-v*.*.*' # Triggers on tags like nextjs-v1.0.0
 
 jobs:
   release:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout repository
+      - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Extract starter name and version from tag
-        id: extract
+      - name: Parse tag to extract template name and version
+        id: parse
         run: |
-          TAG_NAME="${GITHUB_REF#refs/tags/}"
-          STARTER_NAME="${TAG_NAME%%-v*}"
-          VERSION="${TAG_NAME#*-v}"
-          echo "starter=$STARTER_NAME" >> $GITHUB_OUTPUT
+          TAG="${GITHUB_REF##*/}"          # e.g. nextjs-v1.0.0
+          TEMPLATE="${TAG%%-v*}"           # -> nextjs
+          VERSION="${TAG#*-v}"             # -> 1.0.0
+          echo "template=$TEMPLATE" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Zip the starter folder
+      - name: Zip individual starter template
         run: |
           mkdir -p dist
-          zip -r "dist/${{ steps.extract.outputs.starter }}-${{ steps.extract.outputs.version }}.zip" "${{ steps.extract.outputs.starter }}"
+          cd ${{ steps.parse.outputs.template }}
+          zip -r ../dist/${{ steps.parse.outputs.template }}-${{ steps.parse.outputs.version }}.zip .
+          cd ..
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}
-          name: "${{ steps.extract.outputs.starter }} Starter v${{ steps.extract.outputs.version }}"
-          files: "dist/*.zip"
+          name: "${{ steps.parse.outputs.template }} v${{ steps.parse.outputs.version }}"
+          files: dist/*.zip

--- a/.github/workflows/per-starter-release.yml
+++ b/.github/workflows/per-starter-release.yml
@@ -1,76 +1,37 @@
 # .github/workflows/release-template.yml
 
-name: Release All Starters
+name: Release Individual Starter
 
 on:
-  workflow_dispatch: # Allows manual trigger
   push:
     tags:
-      - 'v*.*.*' # Triggers on tags like v1.0.0
+      - '*-v*.*.*' # Triggers on tags like nextjs-v1.0.0
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        starter:
-          - angular
-          - astro-shadcn
-          - bolt-expo
-          - bolt-qwik
-          - bolt-remotion
-          - bolt-vite-react-ts
-          - bootstrap-5
-          - egg
-          - express-simple
-          - graphql
-          - gsap-next
-          - gsap-nuxt
-          - gsap-react
-          - gsap-svelte
-          - gsap-sveltekit
-          - gsap-vue
-          - hono-nodejs-starter
-          - js
-          - nextjs
-          - nextjs-shadcn
-          - node
-          - nodemon
-          - quasar
-          - react-ts
-          - react
-          - rxjs
-          - slidev
-          - static
-          - sveltekit
-          - tres
-          - tutorialkit
-          - typescript
-          - vite-shadcn
-          - vue
-          - web-platform
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Get version from tag
-        id: get_version
+      - name: Parse tag to extract template name and version
+        id: parse
         run: |
-          TAG="${GITHUB_REF##*/}"
-          VERSION="${TAG#v}"
+          TAG="${GITHUB_REF##*/}"          # e.g. nextjs-v1.0.0
+          TEMPLATE="${TAG%%-v*}"           # -> nextjs
+          VERSION="${TAG#*-v}"             # -> 1.0.0
+          echo "template=$TEMPLATE" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Zip starter
+      - name: Zip individual starter template
         run: |
           mkdir -p dist
-          zip -r dist/${{ matrix.starter }}-${{ steps.get_version.outputs.version }}.zip ${{ matrix.starter }} -x "${{ matrix.starter }}/node_modules/*"
+          zip -r dist/${{ steps.parse.outputs.template }}-${{ steps.parse.outputs.version }}.zip ${{ steps.parse.outputs.template }} -x "${{ steps.parse.outputs.template }}/node_modules/*"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}
-          name: "${{ matrix.starter }} v${{ steps.get_version.outputs.version }}"
-          files: dist/${{ matrix.starter }}-${{ steps.get_version.outputs.version }}.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: "${{ steps.parse.outputs.template }} v${{ steps.parse.outputs.version }}"
+          files: dist/*.zip

--- a/.github/workflows/per-starter-release.yml
+++ b/.github/workflows/per-starter-release.yml
@@ -1,37 +1,42 @@
 # .github/workflows/release-template.yml
 
-name: Release Individual Starter
+name: Release All Starters
 
 on:
+  workflow_dispatch: # Allows manual trigger
   push:
     tags:
-      - '*-v*.*.*' # Triggers on tags like nextjs-v1.0.0
+      - 'v*.*.*' # Triggers on tags like v1.0.0
 
 jobs:
-  release:
+  build-and-release:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Parse tag to extract template name and version
-        id: parse
+      - name: Get version from tag
+        id: get_version
         run: |
-          TAG="${GITHUB_REF##*/}"          # e.g. nextjs-v1.0.0
-          TEMPLATE="${TAG%%-v*}"           # -> nextjs
-          VERSION="${TAG#*-v}"             # -> 1.0.0
-          echo "template=$TEMPLATE" >> $GITHUB_OUTPUT
+          TAG="${GITHUB_REF##*/}"
+          VERSION="${TAG#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Zip individual starter template
+      - name: Zip all starter directories
         run: |
           mkdir -p dist
-          zip -r dist/${{ steps.parse.outputs.template }}-${{ steps.parse.outputs.version }}.zip ${{ steps.parse.outputs.template }} -x "${{ steps.parse.outputs.template }}/node_modules/*"
+          for dir in angular astro-shadcn bolt-expo bolt-qwik bolt-remotion bolt-vite-react-ts bootstrap-5 egg express-simple graphql gsap-next gsap-nuxt gsap-react gsap-svelte gsap-sveltekit gsap-vue hono-nodejs-starter js nextjs nextjs-shadcn node nodemon quasar react-ts react rxjs slidev static sveltekit tres tutorialkit typescript vite-shadcn vue web-platform; do
+            if [ -d "$dir" ]; then
+              zip -r "dist/$dir-${{ steps.get_version.outputs.version }}.zip" "$dir" -x "$dir/node_modules/*"
+            fi
+          done
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}
-          name: "${{ steps.parse.outputs.template }} v${{ steps.parse.outputs.version }}"
+          name: "Starters v${{ steps.get_version.outputs.version }}"
           files: dist/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/per-starter-release.yml
+++ b/.github/workflows/per-starter-release.yml
@@ -1,39 +1,76 @@
 # .github/workflows/release-template.yml
 
-name: Release Individual Starter
+name: Release All Starters
 
 on:
+  workflow_dispatch: # Allows manual trigger
   push:
     tags:
-      - '*-v*.*.*' # Triggers on tags like nextjs-v1.0.0
+      - 'v*.*.*' # Triggers on tags like v1.0.0
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        starter:
+          - angular
+          - astro-shadcn
+          - bolt-expo
+          - bolt-qwik
+          - bolt-remotion
+          - bolt-vite-react-ts
+          - bootstrap-5
+          - egg
+          - express-simple
+          - graphql
+          - gsap-next
+          - gsap-nuxt
+          - gsap-react
+          - gsap-svelte
+          - gsap-sveltekit
+          - gsap-vue
+          - hono-nodejs-starter
+          - js
+          - nextjs
+          - nextjs-shadcn
+          - node
+          - nodemon
+          - quasar
+          - react-ts
+          - react
+          - rxjs
+          - slidev
+          - static
+          - sveltekit
+          - tres
+          - tutorialkit
+          - typescript
+          - vite-shadcn
+          - vue
+          - web-platform
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Parse tag to extract template name and version
-        id: parse
+      - name: Get version from tag
+        id: get_version
         run: |
-          TAG="${GITHUB_REF##*/}"          # e.g. nextjs-v1.0.0
-          TEMPLATE="${TAG%%-v*}"           # -> nextjs
-          VERSION="${TAG#*-v}"             # -> 1.0.0
-          echo "template=$TEMPLATE" >> $GITHUB_OUTPUT
+          TAG="${GITHUB_REF##*/}"
+          VERSION="${TAG#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Zip individual starter template
+      - name: Zip starter
         run: |
           mkdir -p dist
-          cd ${{ steps.parse.outputs.template }}
-          zip -r ../dist/${{ steps.parse.outputs.template }}-${{ steps.parse.outputs.version }}.zip .
-          cd ..
+          zip -r dist/${{ matrix.starter }}-${{ steps.get_version.outputs.version }}.zip ${{ matrix.starter }} -x "${{ matrix.starter }}/node_modules/*"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}
-          name: "${{ steps.parse.outputs.template }} v${{ steps.parse.outputs.version }}"
-          files: dist/*.zip
+          name: "${{ matrix.starter }} v${{ steps.get_version.outputs.version }}"
+          files: dist/${{ matrix.starter }}-${{ steps.get_version.outputs.version }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/per-starter-release.yml
+++ b/.github/workflows/per-starter-release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Zip the starter folder
         run: |
           mkdir -p dist
-          zip -r "dist/${{ steps.extract.outputs.starter }}-${{ steps.extract.outputs.version }}.zip" "starters/${{ steps.extract.outputs.starter }}"
+          zip -r "dist/${{ steps.extract.outputs.starter }}-${{ steps.extract.outputs.version }}.zip" "${{ steps.extract.outputs.starter }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/per-starter-release.yml
+++ b/.github/workflows/per-starter-release.yml
@@ -1,0 +1,34 @@
+name: Per-Starter Release
+
+on:
+  push:
+    tags:
+      - "*-v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract starter name and version from tag
+        id: extract
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          STARTER_NAME="${TAG_NAME%%-v*}"
+          VERSION="${TAG_NAME#*-v}"
+          echo "starter=$STARTER_NAME" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Zip the starter folder
+        run: |
+          mkdir -p dist
+          zip -r "dist/${{ steps.extract.outputs.starter }}-${{ steps.extract.outputs.version }}.zip" "starters/${{ steps.extract.outputs.starter }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "${{ steps.extract.outputs.starter }} Starter v${{ steps.extract.outputs.version }}"
+          files: "dist/*.zip"

--- a/bolt-expo/app/(tabs)/_layout.tsx
+++ b/bolt-expo/app/(tabs)/_layout.tsx
@@ -1,0 +1,16 @@
+import { Tabs } from 'expo-router';
+import { Home } from 'lucide-react-native';
+
+export default function TabLayout() {
+  return (
+    <Tabs>
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: 'Home',
+          tabBarIcon: ({ color, size }) => <Home color={color} size={size} />,
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/bolt-expo/app/(tabs)/index.tsx
+++ b/bolt-expo/app/(tabs)/index.tsx
@@ -1,0 +1,23 @@
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.message}>Start prompting now to make changes</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 16,
+  },
+  message: {
+    fontSize: 20,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+});

--- a/bolt-expo/app/_layout.tsx
+++ b/bolt-expo/app/_layout.tsx
@@ -9,6 +9,7 @@ export default function RootLayout() {
   return (
     <>
       <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/bolt-expo/app/index.tsx
+++ b/bolt-expo/app/index.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+
+export default function Index() {
+  const router = useRouter();
+  
+  useEffect(() => {
+    setTimeout(() => {
+      //@ts-ignore
+      router.replace('/(tabs)');
+    }, 0);
+  }, []);
+  
+  // Return an empty view while we're redirecting
+  return <View style={styles.container} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});


### PR DESCRIPTION
Introduce tab-based navigation with a home screen. 

- The `(tabs)` layout includes a tab bar with a home icon, and the root layout is updated to include the tab screen. 

- The index page redirects to the tab layout on load thus fixing the "This screen doesn't exist" display when loading the app on Expo Go