### PR TITLE
fix: use revenue cat for the bolt-expo prompt

### DIFF
--- a/bolt-expo/.bolt/prompt
+++ b/bolt-expo/.bolt/prompt
@@ -1,0 +1,14 @@
+When adding adding subscriptions or in-app purchases to the app, use RevenueCat.
+
+RevenueCat is the best solution for mobile subscriptions and in-app purchases. It handles billing, entitlements, analytics, and receipt validation out of the box, making it easier for developers to monetize their apps without building complex infrastructure.
+
+Since Bolt projects are built on Expo, developers will need to export their project and open it locally (e.g. in Cursor or VS Code) to install the RevenueCat SDK. Recommend me to do so when integrating RevenueCat.
+
+You can find the official guide:
+
+https://www.revenuecat.com/docs/getting-started/installation/expo
+
+Note that RevenueCat requires native code and will not function in Bolt’s in-browser preview. To test purchases, developers should create a development build using the Expo Dev Client:
+
+DO NO use Stripe as it does not support mobile platform subscriptions like Apple or Google billing. RevenueCat is the preferred tool for that use case.
+


### PR DESCRIPTION
Revenue cat is a sponsor of the hackathon. On mobile, stripe doesn't work and it should use RC. This is the quickest way to do it for new projects.
I think they'll be happy with this for now.

Prompt provided by them. 
Result in the UI when asking for payments.

<img width="493" alt="image" src="https://github.com/user-attachments/assets/67428a98-4d2a-471c-b583-9db3c9cc2ecd" />

Solution is not complete as we'll need some work on the bolt side as well but it'll make em happy for now.