### PR TITLE
chore: update GitHub Actions to use Node.js 22 and latest action versions

### DIFF
--- a/.github/workflows/package-lock-sync.yml
+++ b/.github/workflows/package-lock-sync.yml
@@ -9,10 +9,10 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run package:check
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "npm"
+      - run: npm ci --prefer-offline --no-audit
+      - run: npm run package:check

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -9,10 +9,10 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run format:check
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "npm"
+      - run: npm ci --prefer-offline --no-audit
+      - run: npm run format:check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: 18
-          cache: 'npm'
+          node-version: 22
+          cache: "npm"
 
-      - run: npm ci
+      - run: npm ci --prefer-offline --no-audit
 
       - name: Install Playwright Dependencies
         run: npx playwright install chromium --with-deps --only-shell


### PR DESCRIPTION
We're using Node.js 18 in CI and I think that's causing the `package-lock` check to fail.