### PR TITLE
chore: relax noUnusedLocals/noUnusedParameters in vite starters

### DIFF
--- a/bolt-vite-react-ts/tsconfig.app.json
+++ b/bolt-vite-react-ts/tsconfig.app.json
@@ -16,8 +16,8 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"]

--- a/bolt-vite-react-ts/tsconfig.node.json
+++ b/bolt-vite-react-ts/tsconfig.node.json
@@ -14,8 +14,8 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true
   },
   "include": ["vite.config.ts"]

--- a/vite-shadcn/tsconfig.app.json
+++ b/vite-shadcn/tsconfig.app.json
@@ -16,8 +16,8 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
 
     /* for ShadCN */

--- a/vite-shadcn/tsconfig.node.json
+++ b/vite-shadcn/tsconfig.node.json
@@ -14,8 +14,8 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true
   },
   "include": ["vite.config.ts"]


### PR DESCRIPTION
## Summary

Disables `noUnusedLocals` and `noUnusedParameters` in the TypeScript configs of the `bolt-vite-react-ts` and `vite-shadcn` starters (both `tsconfig.app.json` and `tsconfig.node.json`).

Unused-local / unused-parameter (`TS6133` / `TS6196`) is the single most common build failure in agent-generated projects in Bolt — models routinely leave an unused import or arg, which is a harmless warning-class error that shouldn't fail the build. This matches `bolt-slides`, whose `tsconfig.json` already has both disabled.

## Scope

Only the two vite starters set these flags today; the other Bolt starters here either don't set them or already have them off, so nothing else changes.

## Rollout note

Bolt bakes these templates from a pinned commit in `templates.json`. Once this merges, a follow-up bolt PR bumps that pinned SHA so both the client-side chooser and the agent-driven `use_template` flow pick up the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)