### PR TITLE
feat(bolt-vite-react-ts): add @/ path alias for src

### DIFF
--- a/bolt-vite-react-ts/.bolt/prompt
+++ b/bolt-vite-react-ts/.bolt/prompt
@@ -3,3 +3,5 @@ For all designs I ask you to make, have them be beautiful, not cookie cutter. Ma
 By default, this template supports JSX syntax with Tailwind CSS classes, React hooks, and Lucide React for icons. Do not install other packages for UI themes, icons, etc unless absolutely necessary or I request them.
 
 Use icons from lucide-react for logos.
+
+Import project modules with the `@/` path alias (`@/components/Foo`, maps to `src/`) instead of deep relative paths like `../../components/Foo`.

--- a/bolt-vite-react-ts/tsconfig.app.json
+++ b/bolt-vite-react-ts/tsconfig.app.json
@@ -14,6 +14,12 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
+    /* Path alias — depth-invariant imports for src (@/foo === src/foo from any file) */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": false,

--- a/bolt-vite-react-ts/vite.config.ts
+++ b/bolt-vite-react-ts/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath, URL } from 'node:url';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
## What

Adds a depth-invariant `@/*` → `src/*` path alias to the `bolt-vite-react-ts` starter, wired in both places Vite + tsc need it:
- `tsconfig.app.json`: `baseUrl` + `paths`
- `vite.config.ts`: `resolve.alias`

Plus one line in the starter's `.bolt/prompt` steering the agent to prefer `@/` imports over deep relative paths — co-located with the alias it describes, following the existing template-prompt convention.

Verified: `@/`-prefixed imports resolve under both `npm run typecheck` (tsc) and `npm run build` (vite).

## Why

On deep folder layouts, the agent (GLM-5.2 especially) miscounts relative import depth — `../services/x` vs `../../services/x` — against a file that exists, forcing build-failure repair loops. Measured on the `salamtak-clinic` eval: ~1 unresolvable-import build failure per run, from 237 relative cross-directory imports. A `@/` alias is depth-invariant (`@/services/x` is the same from any file), removing the class structurally when the agent adopts it.

Paired with an OSS-gated import-discipline prompt block (bolt PR #6519). Validated via an eval that points `templates.json` at this branch's head: GLM import-failures → 0 across all 20 build specs, no regression for Sonnet.

## Blast radius

Additive and backwards-compatible — existing relative imports keep working; the alias is simply also available. The prompt line only affects new projects scaffolded from this template.
