### PR TITLE
docs(bolt-vite-react-ts): clarify @/ alias mapping in template prompt

### DIFF
--- a/bolt-vite-react-ts/.bolt/prompt
+++ b/bolt-vite-react-ts/.bolt/prompt
@@ -4,4 +4,4 @@ By default, this template supports JSX syntax with Tailwind CSS classes, React h
 
 Use icons from lucide-react for logos.
 
-Import project modules with the `@/` path alias, which maps to `src/` (e.g. `@/components/Foo`), instead of deep relative paths like `../../components/Foo`.
+Import project modules with the `@/` path alias, which maps to `src/` (e.g. `@/components/Foo` == `src/components/Foo`), instead of deep relative paths like `../../components/Foo`.

--- a/bolt-vite-react-ts/.bolt/prompt
+++ b/bolt-vite-react-ts/.bolt/prompt
@@ -4,4 +4,4 @@ By default, this template supports JSX syntax with Tailwind CSS classes, React h
 
 Use icons from lucide-react for logos.
 
-Import project modules with the `@/` path alias (`@/components/Foo`, maps to `src/`) instead of deep relative paths like `../../components/Foo`.
+Import project modules with the `@/` path alias, which maps to `src/` (e.g. `@/components/Foo`), instead of deep relative paths like `../../components/Foo`.


### PR DESCRIPTION
Follow-up to #116, per julio's review: the `(`@/components/Foo`, maps to `src/`)` phrasing read as if the whole path maps to `src/`. Reworded so the alias→root mapping is stated first and the import is the example:

> Import project modules with the `@/` path alias, which maps to `src/` (e.g. `@/components/Foo`), instead of deep relative paths like `../../components/Foo`.
