### PR TITLE
fix(bolt-vite-react-ts): bump lucide-react to ^0.446.0

### DIFF
--- a/bolt-vite-react-ts/package-lock.json
+++ b/bolt-vite-react-ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.57.4",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^0.446.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -2876,11 +2876,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.344.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.344.0.tgz",
-      "integrity": "sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ==",
+      "version": "0.446.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.446.0.tgz",
+      "integrity": "sha512-BU7gy8MfBMqvEdDPH79VhOXSEgyG8TSPOKWaExWGCQVqnGH7wGgDngPbofu+KdtVjPQBWbEmnfMTq90CTiiDRg==",
+      "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/merge2": {

--- a/bolt-vite-react-ts/package.json
+++ b/bolt-vite-react-ts/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.57.4",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^0.446.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },


### PR DESCRIPTION
Models trained on current lucide import post-rename icon names (`LoaderCircle` et al) that don't exist in the template's `^0.344.0` pin — the import fails module evaluation and the app white-screens (verified in gpt-5.6 eval runs; 9/24 terra runs blanked, 3 with this exact error verbatim). `^0.446.0` exports the renamed icons and keeps the legacy aliases Claude models use (`Loader2`, `BarChart3`, `CheckCircle2`), and matches the pin the shadcn templates already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)