### PR TITLE
fix(bolt-slides): distinguish speaker view from present

### DIFF
--- a/bolt-slides/.bolt/skills/slides/SKILL.md
+++ b/bolt-slides/.bolt/skills/slides/SKILL.md
@@ -14,11 +14,11 @@ This repo is a complete slide **studio**. Author content into it.
 
 - `/` — in the Bolt preview iframe (and local Vite): studio. Side panel
   (S) and grid (G) reorder / duplicate / delete; the dock holds notes,
-  Download (PDF or JSON), Present, and Presenter. Present opens a new
+  Download (PDF or JSON), Speaker view, and Present. Present opens a new
   tab (`/?present=1`); the studio stays put. Grid selection is the
   start slide. The published site at `/` is the audience deck (notes
-  stripped). **P** opens the presenter console in a new tab.
-- `/?presenter=1` — presenter console (on-screen now, up next, notes
+  stripped). **P** opens speaker view in a new tab.
+- `/?presenter=1` — speaker view (current slide, up next, notes
   read-only, timer, note text size). `/present` is the same route.
 
 **Your job is CONTENT.** A deck is `deck.json`. Write that file (and

--- a/bolt-slides/README.md
+++ b/bolt-slides/README.md
@@ -25,11 +25,11 @@ or Download as PDF / JSON.
 ## What's inside
 
 - `/` — In Bolt this is the studio: canvas, side panel (S), grid (G),
-  and a floating dock (pager, notes, Download, Present, Presenter).
+  and a floating dock (pager, notes, Download, Speaker view, Present).
   Present opens `/?present=1` in a new tab; the studio stays put.
   Fullscreen is F in that tab. The published origin is the audience
-  deck. **P** opens the presenter console in a second tab.
-- `/?presenter=1` — Presenter console: on-screen now, up next, notes
+  deck. **P** opens speaker view in a second tab.
+- `/?presenter=1` — Speaker view: current slide, up next, notes
   (read-only), timer, note text size. `/present` is the same route.
 
 Collaborate by sharing the Bolt project.

--- a/bolt-slides/src/deck/Dock.tsx
+++ b/bolt-slides/src/deck/Dock.tsx
@@ -402,8 +402,8 @@ const Dock = forwardRef<HTMLDivElement, DockProps>(function Dock(
           <button
             type="button"
             className="noir-icon-btn noir-optional"
-            title="Presenter — new tab (P)"
-            aria-label="Presenter — new tab (P)"
+            title="Speaker view — new tab (P)"
+            aria-label="Speaker view — new tab (P)"
             onClick={onPresenter}
           >
             <IconPresent />

--- a/bolt-slides/src/deck/Presenter.tsx
+++ b/bolt-slides/src/deck/Presenter.tsx
@@ -8,9 +8,9 @@ import {
   IconLeft,
   IconRight,
   IconClose,
-  IconPlay,
   IconPause,
   IconStop,
+  IconStopwatch,
   IconType,
 } from './icons';
 
@@ -133,12 +133,12 @@ export default function Presenter({
           </span>
           <button
             type="button"
-            className={'pres-icon' + (running ? '' : ' is-play')}
+            className="pres-icon"
             onClick={() => setRunning((runningNow) => !runningNow)}
             title={running ? 'Pause (T)' : 'Start (T)'}
             aria-label={running ? 'Pause timer' : 'Start timer'}
           >
-            {running ? <IconPause /> : <IconPlay />}
+            {running ? <IconPause /> : <IconStopwatch />}
           </button>
           <button
             type="button"
@@ -213,7 +213,7 @@ export default function Presenter({
 
       <div className="pres-body">
         <section className="pres-stage">
-          <div className="pres-label">On screen now</div>
+          <div className="pres-label">Current slide</div>
           <div className="pres-now">
             {currentSlide ? (
               <Thumb ctx={liveCtx}>{renderSlide(currentSlide)}</Thumb>

--- a/bolt-slides/src/deck/Presenter.tsx
+++ b/bolt-slides/src/deck/Presenter.tsx
@@ -8,6 +8,7 @@ import {
   IconLeft,
   IconRight,
   IconClose,
+  IconPlay,
   IconPause,
   IconStop,
   IconStopwatch,
@@ -118,6 +119,7 @@ export default function Presenter({
 
   const currentSlide = slides[slideIndex];
   const nextSlide = slides[slideIndex + 1];
+  const timerIdle = !running && elapsed === 0;
   const progress = slideCount > 1 ? (slideIndex / (slideCount - 1)) * 100 : 100;
   const builds =
     buildMax > 0
@@ -133,12 +135,18 @@ export default function Presenter({
           </span>
           <button
             type="button"
-            className="pres-icon"
+            className={'pres-icon' + (!timerIdle && !running ? ' is-play' : '')}
             onClick={() => setRunning((runningNow) => !runningNow)}
             title={running ? 'Pause (T)' : 'Start (T)'}
             aria-label={running ? 'Pause timer' : 'Start timer'}
           >
-            {running ? <IconPause /> : <IconStopwatch />}
+            {timerIdle ? (
+              <IconStopwatch />
+            ) : running ? (
+              <IconPause />
+            ) : (
+              <IconPlay />
+            )}
           </button>
           <button
             type="button"

--- a/bolt-slides/src/deck/icons.tsx
+++ b/bolt-slides/src/deck/icons.tsx
@@ -107,6 +107,16 @@ export const IconPlay = () => (
   </svg>
 );
 
+export const IconStopwatch = () => (
+  <svg {...base}>
+    <path d="M10 3h4" />
+    <path d="M12 3v3" />
+    <circle cx="12" cy="14" r="7" />
+    <path d="M12 14V11" />
+    <path d="M12 14l3.2 2" />
+  </svg>
+);
+
 export const IconPause = () => (
   <svg {...base} fill="currentColor" stroke="none">
     <rect x="7" y="5" width="3.6" height="14" rx="0.8" />

--- a/bolt-slides/src/styles/base.css
+++ b/bolt-slides/src/styles/base.css
@@ -2297,10 +2297,6 @@ strong {
   height: 16px;
   display: block;
 }
-.pres-timer .pres-icon.is-play svg {
-  /* triangle's optical center sits left of the viewBox midpoint */
-  transform: translateX(1px);
-}
 .pres-icon:hover:not(:disabled) {
   background: var(--ed-util-hover);
   color: var(--ed-text);
@@ -2403,7 +2399,7 @@ strong {
   background: var(--ed-bg-secondary);
 }
 
-/* label above the box, exactly like "On screen now" — so both columns start
+/* label above the box, exactly like "Current slide" — so both columns start
    on the same line and their boxes align */
 .pres-notes-col {
   display: flex;

--- a/bolt-slides/src/styles/base.css
+++ b/bolt-slides/src/styles/base.css
@@ -2297,6 +2297,10 @@ strong {
   height: 16px;
   display: block;
 }
+.pres-timer .pres-icon.is-play svg {
+  /* triangle's optical center sits left of the viewBox midpoint */
+  transform: translateX(1px);
+}
 .pres-icon:hover:not(:disabled) {
   background: var(--ed-util-hover);
   color: var(--ed-text);


### PR DESCRIPTION
Speaker view and Present were easy to mix up. The timer used the same play icon as Present, the dock tooltip said Presenter next to Present, and `On screen now` sounded like the deck was already live.

- Timer start (idle) uses a stopwatch
- Once the timer has time on it, the control is play/pause
- `On screen now` is `Current slide`
- Dock tooltip is `Speaker view` instead of `Presenter`

Part of BOU-2738

## Test plan
- [x] Studio dock tooltip reads Speaker view (P), not Presenter
- [x] Present tooltip is unchanged
- [x] Speaker view (`/?presenter=1`) shows Current slide / Up next
- [x] Idle timer shows a stopwatch
- [x] Running timer shows pause; paused timer shows play
- [x] Reset returns the control to the stopwatch